### PR TITLE
fix: changed config for core version to include x.x.x.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,8 +37,9 @@ jobs:
             docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
             docker buildx create --name multiarch --driver docker-container --use
             docker buildx inspect --bootstrap
+            CORE_VERSION_WITH_PATCH=$(cat Dockerfile | grep "ARG CORE_VERSION=" | cut -d'=' -f2)
             CORE_VERSION=$(cat Dockerfile | grep "ARG CORE_VERSION=" | cut -d'=' -f2 | cut -d'.' -f1,2)
-            docker buildx build --platform $BUILDX_PLATFORMS -t supertokens/supertokens-mysql:${CORE_VERSION} -o type=image,push=true .
+            docker buildx build --platform $BUILDX_PLATFORMS -t supertokens/supertokens-mysql:${CORE_VERSION} -t supertokens/supertokens-mysql:${CORE_VERSION_WITH_PATCH} -o type=image,push=true .
       - run:
           name: check if is latest core and plugin and push to docker hub if latest
           command: |


### PR DESCRIPTION
Issue: https://github.com/supertokens/backend/issues/754

Made changes in circleci config for tagging the docker image for supertoken core mysql to enable pushing of x.x.x along with x.x .

Tests performed:
Added multi tagging and fetching the version from docker file. Fetching works fine, tried in local shell and for the tags checked for a dummy container using same syntax, working fine.
For multi tags:
Ran following command locally and tested both tags are present on dockerhub.
docker buildx build -t piyush0810/temp:1 -t piyush0810/temp:2 -o type=image,push=true .