### PR TITLE
fix: docker readonly fs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:bionic-20200219 as tmp
 ARG PLUGIN_NAME=mysql
 ARG PLAN_TYPE=FREE
-ARG CORE_VERSION=9.2.2
+ARG CORE_VERSION=9.2.3
 ARG PLUGIN_VERSION=7.1.3
 RUN apt-get update && apt-get install -y curl zip
 RUN OS= && dpkgArch="$(dpkg --print-architecture)" && \
@@ -37,5 +37,6 @@ COPY docker-entrypoint.sh /usr/local/bin/
 RUN echo "$(md5sum /usr/lib/supertokens/config.yaml | awk '{ print $1 }')" >> /CONFIG_HASH
 RUN ln -s usr/local/bin/docker-entrypoint.sh /entrypoint.sh # backwards compat
 EXPOSE 3567
+USER "supertokens"
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["supertokens", "start"]

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ $ docker run \
 
 
 ## Read-only root fs
-- If you wish to run this container with a read-only root filesystem, you should use the `--read-only` flag *for the container too*.
+- If you wish to run this container with a read-only root filesystem, you can do so.
 - The container still needs a temp area, where it can write its stuff, and also needs to be able to execute from there.
 - You will have to create a mount for `/lib/supertokens/temp/`
 
@@ -122,7 +122,7 @@ docker run \
 	-p 3567:3567 \
 	--mount source=/path/on/host/machine,destination=/lib/supertokens/temp/,type=bind \
 	--read-only \
-	-d registry.supertokens.io/supertokens/supertokens-mysql --read-only
+	-d registry.supertokens.io/supertokens/supertokens-mysql
 ```
 
 ```bash
@@ -130,5 +130,5 @@ docker run \
 	-p 3567:3567 \
 	--tmpfs=/lib/supertokens/temp/:exec \
 	--read-only \
-	-d registry.supertokens.io/supertokens/supertokens-mysql --read-only
+	-d registry.supertokens.io/supertokens/supertokens-mysql
 ```

--- a/README.md
+++ b/README.md
@@ -110,3 +110,25 @@ $ docker run \
 - Before you start this container, make sure to initialize your database.
 - You do not need to ensure that the MySQL database has started before this container is started. During bootup, SuperTokens will wait for ~1 hour for a MySQL instance to be available.
 - If `MYSQL_USER`, `MYSQL_PASSWORD` and `MYSQL_CONNECTION_URI` are not provided, then SuperTokens will use an in memory database.
+
+
+## Read-only root fs
+- If you wish to run this container with a read-only root filesystem, you should use the `--read-only` flag *for the container too*.
+- The container still needs a temp area, where it can write its stuff, and also needs to be able to execute from there.
+- You will have to create a mount for `/lib/supertokens/temp/`
+
+```bash
+docker run \
+	-p 3567:3567 \
+	--mount source=/path/on/host/machine,destination=/lib/supertokens/temp/,type=bind \
+	--read-only \
+	-d registry.supertokens.io/supertokens/supertokens-mysql --read-only
+```
+
+```bash
+docker run \
+	-p 3567:3567 \
+	--tmpfs=/lib/supertokens/temp/:exec \
+	--read-only \
+	-d registry.supertokens.io/supertokens/supertokens-mysql --read-only
+```

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -32,11 +32,24 @@ if [ "${1}" = 'dev' -o "${1}" = "production" -o "${1:0:2}" = "--" ]; then
 fi
 
 CONFIG_FILE=/usr/lib/supertokens/config.yaml
+TEMP_LOCATION_WHEN_READONLY=/lib/supertokens/temp/
 CONFIG_MD5SUM="$(md5sum /usr/lib/supertokens/config.yaml | awk '{ print $1 }')"
 
-# if files have been shared using shared volumes, make sure the ownership of the
-# /usr/lib/supertokens files still remains with supertokens user
-chown -R supertokens:supertokens /usr/lib/supertokens/
+#if it contains the readonly param, make that temp dir a temp dir for java io too
+if [[ "$*" == *--read-only* ]]
+then
+  #required by JNA
+  export _JAVA_OPTIONS=-Djava.io.tmpdir=$TEMP_LOCATION_WHEN_READONLY
+
+  #changing where the config file is written
+  ORIGINAL_CONFIG=$CONFIG_FILE
+  CONFIG_FILE="${TEMP_LOCATION_WHEN_READONLY}/config.yaml"
+  cat $ORIGINAL_CONFIG >> $CONFIG_FILE
+
+  #make sure the CLI knows which config file to pass to the core
+  set -- "$@" --with-config="$CONFIG_FILE" --with-temp-dir="$TEMP_LOCATION_WHEN_READONLY" --foreground
+fi
+
 
 if [ "$CONFIG_HASH" = "$CONFIG_MD5SUM" ]
 then
@@ -204,9 +217,6 @@ then
         then
             touch $INFO_LOG_PATH
         fi
-        # make sure supertokens user has write permission on the file
-        chown supertokens:supertokens $INFO_LOG_PATH
-        chmod +w $INFO_LOG_PATH
         echo "info_log_path: $INFO_LOG_PATH" >> $CONFIG_FILE
     else
         echo "info_log_path: null" >> $CONFIG_FILE
@@ -219,9 +229,6 @@ then
         then
             touch $ERROR_LOG_PATH
         fi
-        # make sure supertokens user has write permission on the file
-        chown supertokens:supertokens $ERROR_LOG_PATH
-        chmod +w $ERROR_LOG_PATH
         echo "error_log_path: $ERROR_LOG_PATH" >> $CONFIG_FILE
     else
         echo "error_log_path: null" >> $CONFIG_FILE
@@ -336,7 +343,7 @@ fi
 # check if no options has been passed to docker run
 if [[ "$@" == "supertokens start" ]]
 then
-    set -- "$@" --foreground
+    set -- "$@" --with-config="$CONFIG_FILE" --foreground
 fi
 
 # If container is started as root user, restart as dedicated supertokens user

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -35,20 +35,18 @@ CONFIG_FILE=/usr/lib/supertokens/config.yaml
 TEMP_LOCATION_WHEN_READONLY=/lib/supertokens/temp/
 CONFIG_MD5SUM="$(md5sum /usr/lib/supertokens/config.yaml | awk '{ print $1 }')"
 
-#if it contains the readonly param, make that temp dir a temp dir for java io too
-if [[ "$*" == *--read-only* ]]
-then
-  #required by JNA
-  export _JAVA_OPTIONS=-Djava.io.tmpdir=$TEMP_LOCATION_WHEN_READONLY
+# always assuming readonly
+#changing where the config file is written
+ORIGINAL_CONFIG=$CONFIG_FILE
+mkdir -p $TEMP_LOCATION_WHEN_READONLY
+CONFIG_FILE="${TEMP_LOCATION_WHEN_READONLY}/config.yaml"
+cat $ORIGINAL_CONFIG >> $CONFIG_FILE
 
-  #changing where the config file is written
-  ORIGINAL_CONFIG=$CONFIG_FILE
-  CONFIG_FILE="${TEMP_LOCATION_WHEN_READONLY}/config.yaml"
-  cat $ORIGINAL_CONFIG >> $CONFIG_FILE
+#required by JNA
+export _JAVA_OPTIONS=-Djava.io.tmpdir=$TEMP_LOCATION_WHEN_READONLY
 
-  #make sure the CLI knows which config file to pass to the core
-  set -- "$@" --with-config="$CONFIG_FILE" --with-temp-dir="$TEMP_LOCATION_WHEN_READONLY" --foreground
-fi
+#make sure the CLI knows which config file to pass to the core
+set -- "$@" --with-config="$CONFIG_FILE" --with-temp-dir="$TEMP_LOCATION_WHEN_READONLY" --foreground
 
 
 if [ "$CONFIG_HASH" = "$CONFIG_MD5SUM" ]

--- a/test.sh
+++ b/test.sh
@@ -186,7 +186,7 @@ git checkout $PWD/config.yaml
 
 #---------------------------------------------------
 # test --read-only
-docker run  --read-only -e DISABLE_TELEMETRY=true $NETWORK_OPTIONS_CONNECTION_URI --tmpfs=/lib/supertokens/temp/:exec --rm -d --name supertokens supertokens-postgresql:circleci --no-in-mem-db --read-only
+docker run  --read-only -e DISABLE_TELEMETRY=true $NETWORK_OPTIONS_CONNECTION_URI --tmpfs=/lib/supertokens/temp/:exec --rm -d --name supertokens supertokens-mysql:circleci --no-in-mem-db --read-only
 
 sleep 17s
 
@@ -204,7 +204,7 @@ docker rm supertokens -f
 
 #---------------------------------------------------
 # test --read-only ARGON2
-docker run  --read-only -e DISABLE_TELEMETRY=true $NETWORK_OPTIONS_CONNECTION_URI -e PASSWORD_HASHING_ALG=ARGON2  --tmpfs=/lib/supertokens/temp/:exec --rm -d --name supertokens supertokens-postgresql:circleci --no-in-mem-db --read-only
+docker run  --read-only -e DISABLE_TELEMETRY=true $NETWORK_OPTIONS_CONNECTION_URI -e PASSWORD_HASHING_ALG=ARGON2  --tmpfs=/lib/supertokens/temp/:exec --rm -d --name supertokens supertokens-mysql:circleci --no-in-mem-db --read-only
 
 sleep 17s
 

--- a/test.sh
+++ b/test.sh
@@ -39,6 +39,32 @@ test_session_post () {
     fi
 }
 
+test_signup_post () {
+    message=$1
+    STATUS_CODE=$(curl -X POST http://127.0.0.1:3567/recipe/signup -H "Content-Type: application/json" -d '{
+        "email": "testing@testing.test",
+        "password": "testpassword"
+    }' -o /dev/null -w '%{http_code}\n' -s)
+    if [[ $STATUS_CODE -ne "200" ]]
+    then
+        printf "\x1b[1;31merror\xd1b[0m from test_signup_post in $message\n"
+        exit 1
+    fi
+}
+
+test_signin_post () {
+    message=$1
+    STATUS_CODE=$(curl -X POST http://127.0.0.1:3567/recipe/signin -H "Content-Type: application/json" -d '{
+        "email": "testing@testing.test",
+        "password": "testpassword"
+    }' -o /dev/null -w '%{http_code}\n' -s)
+    if [[ $STATUS_CODE -ne "200" ]]
+    then
+        printf "\x1b[1;31merror\xd1b[0m from test_signin_post in $message\n"
+        exit 1
+    fi
+}
+
 no_of_containers_running_at_start=`no_of_running_containers`
 
 # start mysql server
@@ -157,6 +183,42 @@ docker rm supertokens -f
 rm -rf $PWD/info.log
 rm -rf $PWD/error.log
 git checkout $PWD/config.yaml
+
+#---------------------------------------------------
+# test --read-only
+docker run  --read-only -e DISABLE_TELEMETRY=true $NETWORK_OPTIONS_CONNECTION_URI --tmpfs=/lib/supertokens/temp/:exec --rm -d --name supertokens supertokens-postgresql:circleci --no-in-mem-db --read-only
+
+sleep 17s
+
+test_equal `no_of_running_containers` $((no_of_containers_running_at_start+2)) "test --read-only"
+
+test_hello "test --read-only"
+
+test_session_post "test --read-only"
+
+test_signup_post "test --read-only"
+
+test_signin_post "test --read-only"
+
+docker rm supertokens -f
+
+#---------------------------------------------------
+# test --read-only ARGON2
+docker run  --read-only -e DISABLE_TELEMETRY=true $NETWORK_OPTIONS_CONNECTION_URI -e PASSWORD_HASHING_ALG=ARGON2  --tmpfs=/lib/supertokens/temp/:exec --rm -d --name supertokens supertokens-postgresql:circleci --no-in-mem-db --read-only
+
+sleep 17s
+
+test_equal `no_of_running_containers` $((no_of_containers_running_at_start+2)) "test --read-only ARGON2"
+
+test_hello "test --read-only ARGON2"
+
+test_session_post "test --read-only ARGON2"
+
+test_signup_post "test --read-only ARGON2"
+
+test_signin_post "test --read-only ARGON2"
+
+docker rm supertokens -f
 
 docker rm mysql -f
 

--- a/test.sh
+++ b/test.sh
@@ -65,6 +65,27 @@ test_signin_post () {
     fi
 }
 
+test_argon2_hash_format () {
+  message=$1
+  result=$(docker exec -it mysql mysql -u root -proot "supertokens" -e "select password_hash from emailpassword_users where email = 'testing@testing.test'")
+  if [[ "$result" != "$argon2"* ]] # doesn't start with $argon2
+    then
+      printf "\x1b[1;31merror\xd1b[0m from test_argon2_hash_format in $message\n"
+      exit 1
+  fi
+}
+
+test_not_argon2_hash_format () {
+  message=$1
+  result=$(docker exec -it mysql mysql -u root -proot "supertokens" -e "select password_hash from emailpassword_users where email = 'testing@testing.test'")
+  if [[ "$result" =~ \$argon2* ]] # starts with $argon2
+    then
+      printf "\x1b[1;31merror\xd1b[0m from test_not_argon2_hash_format in $message\n"
+      exit 1
+  fi
+}
+
+
 no_of_containers_running_at_start=`no_of_running_containers`
 
 # start mysql server
@@ -83,7 +104,7 @@ printf "\nmysql_host: \"$MYSQL_IP\"" >> $PWD/config.yaml
 
 #---------------------------------------------------
 # start with no network options
-docker run -e DISABLE_TELEMETRY=true --rm -d --name supertokens supertokens-mysql:circleci --no-in-mem-db 
+docker run -e DISABLE_TELEMETRY=true --rm -d --name supertokens supertokens-mysql:circleci --no-in-mem-db
 
 sleep 10s
 
@@ -186,7 +207,7 @@ git checkout $PWD/config.yaml
 
 #---------------------------------------------------
 # test --read-only
-docker run  --read-only -e DISABLE_TELEMETRY=true $NETWORK_OPTIONS_CONNECTION_URI --tmpfs=/lib/supertokens/temp/:exec --rm -d --name supertokens supertokens-mysql:circleci --no-in-mem-db --read-only
+docker run  --read-only -e DISABLE_TELEMETRY=true $NETWORK_OPTIONS_CONNECTION_URI --tmpfs=/lib/supertokens/temp/:exec --rm -d --name supertokens supertokens-mysql:circleci --no-in-mem-db
 
 sleep 17s
 
@@ -198,13 +219,15 @@ test_session_post "test --read-only"
 
 test_signup_post "test --read-only"
 
+test_not_argon2_hash_format "test --read-only"
+
 test_signin_post "test --read-only"
 
 docker rm supertokens -f
 
 #---------------------------------------------------
 # test --read-only ARGON2
-docker run  --read-only -e DISABLE_TELEMETRY=true $NETWORK_OPTIONS_CONNECTION_URI -e PASSWORD_HASHING_ALG=ARGON2  --tmpfs=/lib/supertokens/temp/:exec --rm -d --name supertokens supertokens-mysql:circleci --no-in-mem-db --read-only
+docker run  --read-only -e DISABLE_TELEMETRY=true $NETWORK_OPTIONS_CONNECTION_URI -e PASSWORD_HASHING_ALG=ARGON2  --tmpfs=/lib/supertokens/temp/:exec --rm -d --name supertokens supertokens-mysql:circleci --no-in-mem-db
 
 sleep 17s
 
@@ -215,6 +238,8 @@ test_hello "test --read-only ARGON2"
 test_session_post "test --read-only ARGON2"
 
 test_signup_post "test --read-only ARGON2"
+
+test_argon2_hash_format "test --read-only ARGON2"
 
 test_signin_post "test --read-only ARGON2"
 


### PR DESCRIPTION
- Adds support for readonly root filesystem. (--read-only), but for that requires at least a --tmpfs for /lib/supertokens/temp
- Changes the user in the container from root to supertokens
- Removes operations from entrypoint which would require root user.