### PR TITLE
Upgrades core to 10.1.2 to fix WebAuthN issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:bionic-20200219 as tmp
 ARG PLUGIN_NAME=mysql
 ARG PLAN_TYPE=FREE
-ARG CORE_VERSION=10.1.0
+ARG CORE_VERSION=10.1.2
 ARG PLUGIN_VERSION=8.1.0
 RUN apt-get update && apt-get install -y curl zip
 RUN OS= && dpkgArch="$(dpkg --print-architecture)" && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:bionic-20200219 as tmp
 ARG PLUGIN_NAME=mysql
 ARG PLAN_TYPE=FREE
 ARG CORE_VERSION=10.1.2
-ARG PLUGIN_VERSION=8.1.0
+ARG PLUGIN_VERSION=8.1.2
 RUN apt-get update && apt-get install -y curl zip
 RUN OS= && dpkgArch="$(dpkg --print-architecture)" && \
 	case "${dpkgArch##*-}" in \


### PR DESCRIPTION
This is related to #25 

Basically, the issue is resolved when upgrading core to `1.10.2` (the `/public/recipe/webauthn/options/signin` works and the user can see a dialog to execute the passkey procedure) and building the updated image.

I've tested it locally with in-memory database and a MySQL connection. Please let me know if you'd like any changes.